### PR TITLE
Fixed issue #37, NullPointerException when generating views

### DIFF
--- a/scripts/_NgGenerate.groovy
+++ b/scripts/_NgGenerate.groovy
@@ -1,7 +1,7 @@
 import grails.util.GrailsNameUtils
 
 includeTargets << grailsScript("_GrailsCreateArtifacts")
-includeTargets << new File("scaffoldingPluginDir/scripts/_GrailsGenerate.groovy")
+includeTargets << new File("$scaffoldingPluginDir/scripts/_GrailsGenerate.groovy")
 includeTargets << grailsScript("_GrailsBootstrap")
 
 generateForName = null

--- a/src/groovy/grails/plugin/angularscaffolding/AngularTemplateGenerator.groovy
+++ b/src/groovy/grails/plugin/angularscaffolding/AngularTemplateGenerator.groovy
@@ -20,7 +20,7 @@ class AngularTemplateGenerator extends DefaultGrailsTemplateGenerator
 	def renderEditor = { property, prefix ->
 		def domainClass = property.domainClass
 		def cp
-		if (pluginManager?.hasGrailsPlugin('hibernate')) {
+		if (pluginManager?.hasGrailsPlugin('hibernate4')||pluginManager?.hasGrailsPlugin('hibernate3')) {
 			cp = domainClass.constrainedProperties[property.name]
 		}
 

--- a/src/templates/scaffolding/renderEditor.template
+++ b/src/templates/scaffolding/renderEditor.template
@@ -1,7 +1,8 @@
 <%
-        if (pluginManager?.hasGrailsPlugin('hibernate')) {
-   			cp = domainClass.constrainedProperties[property.name]
-   		}
+    if (pluginManager?.hasGrailsPlugin('hibernate4') || pluginManager?.hasGrailsPlugin('hibernate3')) {
+        cp = domainClass.constrainedProperties[property.name]
+    }
+
 	def name = prefix ? "${prefix}${property.name}" : property.name
 
     switch (property.type) {

--- a/src/templates/scaffolding/renderEditor.template
+++ b/src/templates/scaffolding/renderEditor.template
@@ -1,4 +1,7 @@
 <%
+        if (pluginManager?.hasGrailsPlugin('hibernate')) {
+   			cp = domainClass.constrainedProperties[property.name]
+   		}
 	def name = prefix ? "${prefix}${property.name}" : property.name
 
     switch (property.type) {


### PR DESCRIPTION
Fix for https://github.com/robfletcher/grails-angular-scaffolding/issues/37. I installed the plugin as an inplace plugin and fixed issues  #37! There were two problems with the plugin when running from my system. 
- The first problem was on  [scripts/_NgGenerate.groovy:4](https://github.com/amexboy/grails-angular-scaffolding/blob/5e7a2683a4bdc03aa6e7c32972a9efbaba9b729b/scripts/_NgGenerate.groovy#L4) that `scaffoldingPluginDir` was provided as a string and it was supposed to accessing a variable.
- The second problem was causing NullPointerException on every line that `cp` was accessed. The variable wasn't being set properly. First thing the name of the plugin for hibernate had to have the version appended and (I couldn't figure out why,) but `cp` wasn't being bind properly
